### PR TITLE
pose-detection use local movenet model file

### DIFF
--- a/pose-detection/src/movenet/detector.ts
+++ b/pose-detection/src/movenet/detector.ts
@@ -511,7 +511,7 @@ export async function load(modelConfig: MoveNetModelConfig = MOVENET_CONFIG):
   let fromTFHub = true;
 
   if (!!config.modelUrl) {
-    fromTFHub = config.modelUrl.indexOf('https://tfhub.dev') > -1;
+    fromTFHub = typeof config.modelUrl === 'string' && config.modelUrl.indexOf('https://tfhub.dev') > -1;
     model = await tfc.loadGraphModel(config.modelUrl, {fromTFHub});
   } else {
     let modelUrl;


### PR DESCRIPTION
the argument "modelConfig.modelUrl" is only supported for string but iohandler
when I try to  resolve the problem of area/countries that don't have access to the model hosted on tf.hub. and I passed the modelUrl like a iohandler，but cause an error indexOf is not undefined. so i put the url check code to resolve this problem